### PR TITLE
Fix relative import in example

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -5,9 +5,10 @@
 package consistent_test
 
 import (
-	"../consistent"
 	"fmt"
 	"log"
+
+	"github.com/micro/consistent"
 )
 
 func ExampleNew() {


### PR DESCRIPTION
It breaks static analysis. See golang/dep#219.